### PR TITLE
feat: プレフィックスコマンドからスラッシュコマンドに変更

### DIFF
--- a/command.yml
+++ b/command.yml
@@ -1,7 +1,7 @@
 command:
   help:
     desc: 'ヘルプを表示します。'
-    usage: '`help [command]` で使用方法を表示します。'
+    usage: '`/help [command]` で使用方法を表示します。'
   summon:
     desc: '読み上げBotを呼び出します。'
     usage: '引数は必要ありません。'
@@ -17,3 +17,6 @@ command:
   reconnect:
     desc: '読み上げBotを再接続します。読み上げされない場合に有効かもしれません。'
     usage: '引数は必要ありません。'
+  eval:
+    desc: 'コードを実行します（開発者用）。'
+    usage: '`/eval code` でコードを実行します。'

--- a/core/modules/commands/bye.rb
+++ b/core/modules/commands/bye.rb
@@ -4,14 +4,18 @@ module YourSaySan
   module Commands
     # Byeコマンドモジュール
     module Bye
-      extend Discordrb::Commands::CommandContainer
+      extend Discordrb::EventContainer
 
-      command :bye do |event|
-        if event.author.voice_channel
+      def self.register_slash_command(bot)
+        bot.register_application_command(:bye, '読み上げBotを切断します')
+      end
+
+      application_command :bye do |event|
+        if event.user.voice_channel
           YourSaySan::BOT.voice_destroy(event.server)
-          'ボイスチャットから切断しました。'
+          event.respond(content: 'ボイスチャットから切断しました。', ephemeral: true)
         else
-          'ボイスチャットに参加していません。'
+          event.respond(content: 'ボイスチャットに参加していません。', ephemeral: true)
         end
       end
     end

--- a/core/modules/commands/help.rb
+++ b/core/modules/commands/help.rb
@@ -7,27 +7,42 @@ module YourSaySan
   module Commands
     # Help command
     module Help
-      extend Discordrb::Commands::CommandContainer
-      command(:help) do |event, command|
+      extend Discordrb::EventContainer
+      
+      def self.register_slash_command(bot)
+        bot.register_application_command(:help, 'ヘルプを表示します') do |cmd|
+          cmd.string(:command, 'コマンド名（省略可）', required: false)
+        end
+      end
+      
+      application_command(:help) do |event|
         config = YAML.load_file('command.yml')
         help_map = config['command'] || {}
+        
+        # オプションを取得（複数の方法を試す）
+        command_option = nil
+        if event.respond_to?(:options) && event.options.is_a?(Hash)
+          command_option = event.options['command']
+        elsif event.respond_to?(:data) && event.data&.options
+          command_option = event.data.options.find { |opt| opt.name == 'command' }&.value
+        end
 
         # 一覧表示
-        if command.nil? || command.strip.empty?
+        if command_option.nil? || command_option.to_s.strip.empty?
           lines = [
             '読み上げBOTに使用できるコマンドです:',
-            *help_map.map { |name, meta| "- !#{name}: #{meta['desc']}" }
+            *help_map.map { |name, meta| "- /#{name}: #{meta['desc']}" }
           ]
-          event.respond(lines.join("\n"))
+          event.respond(content: lines.join("\n"), ephemeral: true)
           next
         end
 
         # 詳細表示
-        meta = help_map[command]
+        meta = help_map[command_option.to_s]
         if meta
-          event.respond("!#{command}: #{meta['desc']}\n使い方: #{meta['usage']}")
+          event.respond(content: "/#{command_option}: #{meta['desc']}\n使い方: #{meta['usage']}", ephemeral: true)
         else
-          event.respond("'#{command}' は存在しません。!help で一覧を確認してください。")
+          event.respond(content: "'#{command_option}' は存在しません。/help で一覧を確認してください。", ephemeral: true)
         end
       end
     end

--- a/core/modules/commands/ping.rb
+++ b/core/modules/commands/ping.rb
@@ -4,10 +4,14 @@ module YourSaySan
   module Commands
     # Pingコマンドモジュール
     module Ping
-      extend Discordrb::Commands::CommandContainer
+      extend Discordrb::EventContainer
 
-      command :ping do |event|
-        event.respond 'Pong!'
+      def self.register_slash_command(bot)
+        bot.register_application_command(:ping, 'Pongを返します')
+      end
+
+      application_command :ping do |event|
+        event.respond(content: 'Pong!', ephemeral: true)
       end
     end
   end

--- a/core/modules/commands/reconnect.rb
+++ b/core/modules/commands/reconnect.rb
@@ -4,15 +4,19 @@ module YourSaySan
   module Commands
     # Reconnectコマンドモジュール
     module Reconnect
-      extend Discordrb::Commands::CommandContainer
+      extend Discordrb::EventContainer
 
-      command :reconnect do |event|
-        if event.author.voice_channel
+      def self.register_slash_command(bot)
+        bot.register_application_command(:reconnect, '読み上げBotを再接続します')
+      end
+
+      application_command :reconnect do |event|
+        if event.user.voice_channel
           YourSaySan::BOT.voice_destroy(event.server)
-          YourSaySan::BOT.voice_connect(event.author.voice_channel)
-          '再接続しました。'
+          YourSaySan::BOT.voice_connect(event.user.voice_channel)
+          event.respond(content: '再接続しました。', ephemeral: true)
         else
-          'ボイスチャットに参加してください。'
+          event.respond(content: 'ボイスチャットに参加してください。', ephemeral: true)
         end
       end
     end

--- a/core/modules/commands/stop.rb
+++ b/core/modules/commands/stop.rb
@@ -5,13 +5,18 @@ module YourSaySan
   module Commands
     # Command to interrupt someone speaking
     module Stop
-      extend Discordrb::Commands::CommandContainer
-      command(:stop) do |event|
+      extend Discordrb::EventContainer
+      
+      def self.register_slash_command(bot)
+        bot.register_application_command(:stop, '読み上げを中断します')
+      end
+      
+      application_command(:stop) do |event|
         if event.voice
           event.voice.stop_playing if event.voice.playing?
-          nil
+          event.respond(content: '読み上げを停止しました。', ephemeral: true)
         else
-          event.respond('VCに参加していません。')
+          event.respond(content: 'VCに参加していません。', ephemeral: true)
         end
       end
     end

--- a/core/modules/commands/summon.rb
+++ b/core/modules/commands/summon.rb
@@ -4,15 +4,19 @@ module YourSaySan
   module Commands
     # Summonコマンドモジュール
     module Summon
-      extend Discordrb::Commands::CommandContainer
+      extend Discordrb::EventContainer
 
-      command :summon do |event|
-        if event.author.voice_channel
-          YourSaySan::BOT.voice_connect(event.author.voice_channel)
+      def self.register_slash_command(bot)
+        bot.register_application_command(:summon, '読み上げBotを呼び出します')
+      end
+
+      application_command :summon do |event|
+        if event.user.voice_channel
+          YourSaySan::BOT.voice_connect(event.user.voice_channel)
           YourSaySan.text_channels << event.channel.id unless YourSaySan.text_channels.include?(event.channel.id)
-          'ボイスチャットに参加しました。'
+          event.respond(content: 'ボイスチャットに参加しました。', ephemeral: true)
         else
-          'ボイスチャットに参加してください。'
+          event.respond(content: 'ボイスチャットに参加してください。', ephemeral: true)
         end
       end
     end

--- a/core/modules/events/read.rb
+++ b/core/modules/events/read.rb
@@ -10,7 +10,10 @@ module YourSaySan
       require 'uri'
 
       def self.setup(bot, text_channels, voicevox, config)
-        bot.message(start_with: not!(bot.prefix), in: text_channels) do |event|
+        bot.message(in: text_channels) do |event|
+          # スラッシュコマンドの場合は読み上げない
+          next if event.message.content.start_with?('/')
+          
           if event.voice
             next if event.message.content == '' # 画像など本文がない投稿を弾く
 

--- a/core/yoursay.rb
+++ b/core/yoursay.rb
@@ -15,10 +15,9 @@ module YourSaySan
     yaml = YAML.safe_load(erb.result, aliases: true)
     Config.load_and_set_settings(yaml)
   end
-  BOT = Discordrb::Commands::CommandBot.new(
+  BOT = Discordrb::Bot.new(
     token: CONFIG.bot.token,
     client_id: CONFIG.bot.client_id,
-    prefix: CONFIG.bot.prefix,
     ignore_bots: true
   )
 
@@ -63,6 +62,22 @@ module YourSaySan
       # イベントモジュールが setup を提供している場合のみ呼ぶ（テストで差し替え可能）
       mod_ref.setup(BOT, @text_channels, @voicevox, CONFIG) if mod_ref.respond_to?(:setup)
     end
+
+    # 各コマンドモジュールのスラッシュコマンド登録を実行
+    register_slash_commands_from_modules
+  end
+
+  def self.register_slash_commands_from_modules
+    puts '[Bot] スラッシュコマンドの登録開始'
+    
+    Commands.constants.each do |mod|
+      mod_ref = Commands.const_get mod
+      if mod_ref.respond_to?(:register_slash_command)
+        mod_ref.register_slash_command(BOT)
+      end
+    end
+
+    puts '[Bot] スラッシュコマンドの登録完了'
   end
 
   def self.run


### PR DESCRIPTION
- 各コマンドモジュールにregister_slash_commandメソッドを追加
- オプション付きコマンド（help, eval）の実装
- メインファイルからスラッシュコマンド登録を分離
- 読み上げ機能でスラッシュコマンドを除外するように修正

変更ファイル:
- core/yoursay.rb: Botクラス変更とスラッシュコマンド登録分離
- core/modules/commands/*.rb: 各コマンドのスラッシュコマンド対応
- core/modules/events/read.rb: スラッシュコマンド除外処理追加
- command.yml: 使用方法をスラッシュコマンド形式に更新