### PR TITLE
fix: Discordrb 3.5.0でrun_asyncメソッドが存在しない問題を修正

### DIFF
--- a/core/modules/events/auto_reconnect.rb
+++ b/core/modules/events/auto_reconnect.rb
@@ -9,22 +9,8 @@ module YourSaySan
       # 接続断を検知した時の処理
       disconnected do |event|
         puts "[Bot] WebSocket接続が切断されました: #{Time.now}"
-        puts "[Bot] 自動再接続を試行します..."
-        
-        # 少し待ってから再接続を試行
-        Thread.new do
-          sleep 5  # 5秒待機
-          begin
-            puts "[Bot] 再接続を開始します..."
-            event.bot.run_async
-            puts "[Bot] 再接続が完了しました"
-          rescue StandardError => e
-            puts "[Bot] 再接続に失敗しました: #{e.message}"
-            # 再接続に失敗した場合は、さらに待ってから再試行
-            sleep 30
-            retry
-          end
-        end
+        puts "[Bot] Discordrbの自動再接続機能が動作します..."
+        # Discordrbが自動的に再接続を行うため、手動での再接続処理は不要
       end
 
       # 接続が確立された時の処理

--- a/core/modules/events/connection_monitor.rb
+++ b/core/modules/events/connection_monitor.rb
@@ -34,47 +34,21 @@ module YourSaySan
             sleep @config.bot.auto_reconnect.check_interval
             
             begin
-              # 最後のハートビートから設定された時間以上経過している場合は再接続
+              # 最後のハートビートから設定された時間以上経過している場合はログ出力
               if Time.now - @last_heartbeat > @config.bot.auto_reconnect.heartbeat_timeout
-                puts "[Bot] ハートビートが#{@config.bot.auto_reconnect.heartbeat_timeout}秒以上途絶えています。再接続を試行します..."
-                reconnect_bot
+                puts "[Bot] ハートビートが#{@config.bot.auto_reconnect.heartbeat_timeout}秒以上途絶えています。"
+                puts "[Bot] Discordrbの自動再接続機能に任せます..."
               end
               
               # Botの接続状態をチェック
               unless @bot.connected?
-                puts "[Bot] Botが切断状態です。再接続を試行します..."
-                reconnect_bot
+                puts "[Bot] Botが切断状態です。"
+                puts "[Bot] Discordrbの自動再接続機能に任せます..."
               end
               
             rescue StandardError => e
               puts "[Bot] 接続監視中にエラーが発生しました: #{e.message}"
             end
-          end
-        end
-      end
-
-      def self.reconnect_bot
-        begin
-          puts "[Bot] 自動再接続を開始します..."
-          
-          # 既存の接続をクリーンアップ
-          @bot.stop if @bot.connected?
-          
-          # 少し待ってから再接続
-          sleep 5
-          
-          # 非同期で再接続
-          @bot.run_async
-          
-          puts "[Bot] 自動再接続が完了しました"
-          
-        rescue StandardError => e
-          puts "[Bot] 自動再接続に失敗しました: #{e.message}"
-          
-          # 失敗した場合は設定された時間後に再試行
-          Thread.new do
-            sleep @config.bot.auto_reconnect.retry_delay
-            reconnect_bot
           end
         end
       end


### PR DESCRIPTION
- auto_reconnect.rb: 手動の再接続処理を削除し、Discordrbの自動再接続機能に任せる
- connection_monitor.rb: 手動の再接続処理を削除し、監視とログ出力のみに変更
- Discordrbの標準的な自動再接続機能との競合を解消