### PR TITLE
fix: speaker_listコマンドのエラーハンドリングを改善

### DIFF
--- a/core/modules/commands/speaker.rb
+++ b/core/modules/commands/speaker.rb
@@ -14,6 +14,12 @@ module YourSaySan
 
       application_command :speaker do |event|
         speaker_manager = YourSaySan.speaker_manager
+        
+        if speaker_manager.nil?
+          event.respond(content: "話者マネージャーが初期化されていません。VoiceVoxの設定を確認してください。", ephemeral: true)
+          return
+        end
+        
         speakers = speaker_manager.get_available_speakers
 
         if speakers.nil?

--- a/core/modules/commands/speaker_list.rb
+++ b/core/modules/commands/speaker_list.rb
@@ -14,6 +14,12 @@ module YourSaySan
 
       application_command :speaker_list do |event|
         speaker_manager = YourSaySan.speaker_manager
+        
+        if speaker_manager.nil?
+          event.respond(content: "話者マネージャーが初期化されていません。VoiceVoxの設定を確認してください。", ephemeral: true)
+          return
+        end
+        
         speakers = speaker_manager.get_available_speakers
 
         if speakers.nil?

--- a/core/speaker_manager.rb
+++ b/core/speaker_manager.rb
@@ -33,12 +33,14 @@ class SpeakerManager
 
   # VoiceVoxのAPIから利用可能な話者の一覧を取得
   def get_available_speakers
+    return nil if @voicevox.nil?
     @voicevox.get_speakers
   end
 
   # 話者IDが有効かチェック
   def valid_speaker?(speaker_id)
     speakers = get_available_speakers
-    speakers && speakers.key?(speaker_id.to_i)
+    return false if speakers.nil?
+    speakers.key?(speaker_id.to_i)
   end
 end


### PR DESCRIPTION
- speaker_managerがnilの場合のエラーハンドリングを追加
- voicevoxがnilの場合のエラーハンドリングを追加
- 本番環境でVoiceVoxのAPIに接続できない場合の適切なエラーメッセージを表示